### PR TITLE
Add all existing similarities

### DIFF
--- a/fp300.mjs
+++ b/fp300.mjs
@@ -12,8 +12,13 @@ export default {
     model: "FP300",
     vendor: "Aqara",
     description: "Presence sensor FP300",
-    fromZigbee: [lumi.fromZigbee.lumi_specific],
-    toZigbee: [lumi.toZigbee.lumi_motion_sensitivity],
+    fromZigbee: [
+        lumi.fromZigbee.lumi_specific
+    ],
+    toZigbee: [
+        lumi.toZigbee.lumi_presence,
+        lumi.toZigbee.lumi_motion_sensitivity
+    ],
     exposes: [
         e.power_outage_count(), // Works
         e
@@ -27,12 +32,13 @@ export default {
     },
     extend: [
         lumi.lumiModernExtend.fp1ePresence(), // Works
+        // Should adjust https://github.com/Koenkk/zigbee-herdsman-converters/blob/0755b15bf878f2261f17956efb12e52e91642cfa/src/lib/lumi.ts#L709
         modernExtend.illuminance(), // Works
         modernExtend.humidity(), // Works
         modernExtend.temperature(), // Works
         modernExtend.battery(),
-        lumi.lumiModernExtend.fp1eSpatialLearning(),
-        lumi.lumiModernExtend.lumiLedIndicator(), // Works?
+        lumi.lumiModernExtend.fp1eSpatialLearning(), // Works?
+        lumi.lumiModernExtend.lumiLedIndicator(), // Works
         lumi.lumiModernExtend.fp1eRestartDevice(), // Works
         modernExtend.identify(), // Works
 

--- a/fp300.mjs
+++ b/fp300.mjs
@@ -6,9 +6,6 @@ const e = exposes.presets;
 const ea = exposes.access;
 
 const {manufacturerCode} = lumi;
-const manufacturerOptions = {
-    lumi: {manufacturerCode: manufacturerCode, disableDefaultResponse: true},
-};
 
 export default {
     zigbeeModel: ["lumi.sensor_occupy.agl8"],

--- a/fp300.mjs
+++ b/fp300.mjs
@@ -12,9 +12,9 @@ const manufacturerOptions = {
 
 export default {
     zigbeeModel: ["lumi.sensor_occupy.agl8"],
-    model: "lumi.sensor_occupy.agl8",
+    model: "FP300",
     vendor: "Aqara",
-    description: "FP300 Presence Sensor",
+    description: "Presence sensor FP300",
     fromZigbee: [lumi.fromZigbee.lumi_specific],
     toZigbee: [lumi.toZigbee.lumi_motion_sensitivity],
     exposes: [

--- a/fp300.mjs
+++ b/fp300.mjs
@@ -10,23 +10,6 @@ const manufacturerOptions = {
     lumi: {manufacturerCode: manufacturerCode, disableDefaultResponse: true},
 };
 
-export const fp300 = {
-    SpatialLearning: () => {
-        return {
-            isModernExtend: true,
-            exposes: [e.enum("spatial_learning", ea.SET, ["Start Learning"]).withDescription("Initiate AI Spatial Learning.")],
-            toZigbee: [
-                {
-                    key: ["spatial_learning"],
-                    convertSet: async (entity, key, value, meta) => {
-                        await entity.write("manuSpecificLumi", {343: {value: 1, type: 0x20}}, manufacturerOptions.lumi);
-                    },
-                },
-            ],
-        };
-    },
-};
-
 export default {
     zigbeeModel: ["lumi.sensor_occupy.agl8"],
     model: "lumi.sensor_occupy.agl8",
@@ -51,7 +34,7 @@ export default {
         modernExtend.humidity(), // Works
         modernExtend.temperature(), // Works
         modernExtend.battery(),
-        fp300.SpatialLearning(),
+        lumi.lumiModernExtend.fp1eSpatialLearning(),
         lumi.lumiModernExtend.lumiLedIndicator(), // Works?
         lumi.lumiModernExtend.fp1eRestartDevice(), // Works
         modernExtend.identify(), // Works


### PR DESCRIPTION
I've reviewed Aqara lumi devices and related handlers that are already implemented. I've copied over all similarities but that's where they end. Need to figure out / reverse engineer the rest on from there.

PS: I've also added the OTA retrieval line from some device. It seems to work (?) at least for me. Upon adding it, a lot of things started being recognized by Zigbee2MQTT including the version.
(Apologies for pushing it directly to main - I've mistakenly opened web ide on wrong branch...)